### PR TITLE
Make emm-notifications build again.

### DIFF
--- a/emm-notifications/pom.xml
+++ b/emm-notifications/pom.xml
@@ -8,36 +8,30 @@
   <name>emm-notifications</name>
   <url>http://maven.apache.org</url>
 
-  <pluginRepositories>
-    <pluginRepository>
-      <id>protoc-plugin</id>
-      <url>http://sergei-ivanov.github.com/maven-protoc-plugin/repo/releases/</url>
-    </pluginRepository>
-  </pluginRepositories>
-
 
   <build>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.5.1</version>
         <configuration>
           <source>1.5</source>
           <target>1.5</target>
         </configuration>
       </plugin>
       <plugin>
-        <groupId>com.google.protobuf.tools</groupId>
-        <artifactId>maven-protoc-plugin</artifactId>
-        <version>0.3.2</version>
+        <groupId>org.xolstice.maven.plugins</groupId>
+        <artifactId>protobuf-maven-plugin</artifactId>
+        <version>0.5.0</version>
         <configuration>
-          <protocExecutable>/usr/bin/protoc</protocExecutable>
+          <protocExecutable>/usr/local/bin/protoc</protocExecutable>
         </configuration>
         <executions>
           <execution>
             <goals>
               <goal>compile</goal>
-              <goal>testCompile</goal>
+              <goal>test-compile</goal>
             </goals>
           </execution>
         </executions>
@@ -59,12 +53,6 @@
   </build>
 
   <dependencies>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>3.8.1</version>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>

--- a/emm-notifications/src/main/java/com/google/android/work/emmnotifications/TestPublisher.java
+++ b/emm-notifications/src/main/java/com/google/android/work/emmnotifications/TestPublisher.java
@@ -23,8 +23,6 @@ import com.google.api.services.pubsub.model.PublishRequest;
 import com.google.api.services.pubsub.model.PubsubMessage;
 import com.google.api.services.pubsub.model.Topic;
 import com.google.common.collect.ImmutableList;
-import com.google.common.time.Clock;
-import com.google.common.time.SystemClock;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -82,14 +80,13 @@ public class TestPublisher {
     }
 
     ImmutableList.Builder<PubsubMessage> listBuilder = ImmutableList.builder();
-    Clock clock = new SystemClock();
 
     EmmPubsub.MdmPushNotification mdmPushNotification = EmmPubsub.MdmPushNotification.newBuilder()
         .setEnterpriseId("12321321")
-        .setEventNotificationSentTimestampMillis(clock.now().getMillis())
+        .setEventNotificationSentTimestampMillis(System.currentTimeMillis())
         .addProductApprovalEvent(EmmPubsub.ProductApprovalEvent.newBuilder()
             .setApproved(EmmPubsub.ProductApprovalEvent.ApprovalStatus.UNAPPROVED)
-            .setProductId("app:com.android.chrome")
+            .setProductId("app:com.android.chrome"))
         .build();
 
     PublishRequest publishRequest = new PublishRequest()


### PR DESCRIPTION
There were plain compilation issues (missing paren and using non-existent time classes), some weirdness in the pom file plus plain bit rot on the protoc compiler plugin.

With these changes I can compile the code again (I still have to make sure `protoc` is in `/usr/local/bin/` — other locations on `$PATH` are not good enough).