### PR TITLE
Support new formatting of aapt output

### DIFF
--- a/externally-hosted-apks/externallyhosted.py
+++ b/externally-hosted-apks/externallyhosted.py
@@ -144,6 +144,8 @@ class AaptParser(AbstractApkParser):
         output["application_label"] = matches.group(1)
       matches = self.APPLICATION_REGEX.match(line)
       if matches:
+        # In the case that the explicit application-label field is not found
+        # in the aapt output, we grab it from the application regex.
         if "application_label" not in output:
           output["application_label"] = matches.group(1)
         output["icon_filename"] = matches.group(2)

--- a/externally-hosted-apks/externallyhosted.py
+++ b/externally-hosted-apks/externallyhosted.py
@@ -144,8 +144,10 @@ class AaptParser(AbstractApkParser):
         output["application_label"] = matches.group(1)
       matches = self.APPLICATION_REGEX.match(line)
       if matches:
-        # In the case that the explicit application-label field is not found
-        # in the aapt output, we grab it from the application field.
+        # In the case that the explicit "application-label" field is not found
+        # in the aapt output, we grab it from the"application" field.
+        # (more recent versions of aapt only provide localized versions of
+        # application-label in the form "application-label-xx[-XX]")
         if "application_label" not in output:
           output["application_label"] = matches.group(1)
         output["icon_filename"] = matches.group(2)

--- a/externally-hosted-apks/externallyhosted.py
+++ b/externally-hosted-apks/externallyhosted.py
@@ -145,7 +145,7 @@ class AaptParser(AbstractApkParser):
       matches = self.APPLICATION_REGEX.match(line)
       if matches:
         # In the case that the explicit "application-label" field is not found
-        # in the aapt output, we grab it from the"application" field.
+        # in the aapt output, we grab it from the "application" field.
         # (more recent versions of aapt only provide localized versions of
         # application-label in the form "application-label-xx[-XX]")
         if "application_label" not in output:

--- a/externally-hosted-apks/externallyhosted.py
+++ b/externally-hosted-apks/externallyhosted.py
@@ -128,37 +128,33 @@ class AaptParser(AbstractApkParser):
     output = {}
     for line in self.run_aapt():
       matches = self.PACKAGE_MATCH_REGEX.match(line)
-      if matches is not None:
+      if matches:
         _log.info("Matched package")
         output["package_name"] = matches.group(1)
         output["version_code"] = matches.group(2)
         output["version_name"] = matches.group(3)
       matches = self.SDK_VERSION_REGEX.match(line)
-      if matches is not None:
+      if matches:
         output["minimum_sdk"] = matches.group(1)
       matches = self.MAX_SDK_VERSION_REGEX.match(line)
-      if matches is not None:
+      if matches:
         output["maximum_sdk"] = matches.group(1)
       matches = self.APPLICATION_LABEL.match(line)
-      if matches is not None:
+      if matches:
         output["application_label"] = matches.group(1)
       matches = self.APPLICATION_REGEX.match(line)
-      if matches is not None:
+      if matches:
+        if "application_label" not in output:
+          output["application_label"] = matches.group(1)
         output["icon_filename"] = matches.group(2)
       matches = self.USES_FEATURE_REGEX.match(line)
-      if matches is not None:
-        if output.get("uses_feature") is None:
-          output["uses_feature"] = []
-        output["uses_feature"].append(matches.group(1))
+      if matches:
+        output.setdefault("uses_feature", []).append(matches.group(1))
       matches = self.USES_PERMISSION_REGEX_OLD.match(line)
-      if matches is not None:
-        if output.get("uses_permission") is None:
-          output["uses_permission"] = []
-        output["uses_permission"].append({"name": matches.group(1)})
+      if matches:
+        output.setdefault("uses_permission", []).append({"name": matches.group(1)})
       matches = self.USES_PERMISSION_REGEX_NEW.match(line)
-      if matches is not None:
-        if output.get("uses_permission") is None:
-          output["uses_permission"] = []
+      if matches:
         new_permission = {"name": matches.group(1)}
         try:
           if matches.group(2) is not None:
@@ -166,7 +162,7 @@ class AaptParser(AbstractApkParser):
         except IndexError:
           # No maxSdkVersion - that's OK, it's not mandatory
           pass
-        output["uses_permission"].append(new_permission)
+        output.setdefault("uses_permission", []).append(new_permission)
     return output
 
 

--- a/externally-hosted-apks/externallyhosted.py
+++ b/externally-hosted-apks/externallyhosted.py
@@ -145,7 +145,7 @@ class AaptParser(AbstractApkParser):
       matches = self.APPLICATION_REGEX.match(line)
       if matches:
         # In the case that the explicit application-label field is not found
-        # in the aapt output, we grab it from the application regex.
+        # in the aapt output, we grab it from the application field.
         if "application_label" not in output:
           output["application_label"] = matches.group(1)
         output["icon_filename"] = matches.group(2)

--- a/externally-hosted-apks/externallyhosted.py
+++ b/externally-hosted-apks/externallyhosted.py
@@ -146,8 +146,8 @@ class AaptParser(AbstractApkParser):
       if matches:
         # In the case that the explicit "application-label" field is not found
         # in the aapt output, we grab it from the "application" field.
-        # (more recent versions of aapt only provide localized versions of
-        # application-label in the form "application-label-xx[-XX]")
+        # (More recent versions of aapt only provide localized versions of
+        # application-label in the form "application-label-xx[-XX]".)
         if "application_label" not in output:
           output["application_label"] = matches.group(1)
         output["icon_filename"] = matches.group(2)


### PR DESCRIPTION
Previously, the output of aapt would include the line

application-label: 'FooApp'

The previously version of the externallyhosted.py script selected the application under the assumption that the above line would exist. The latest version of aapt only includes localized versions of application label e.g.:

application-label-af: 'FooApp'
application-label-am: 'FooApp'
...

In the case that the original 'application-label:' attribute doesn't exist, the script will now grab the label from the "application:" line which follows the form:

application: label='FooApp' icon='res/mipmap-mdpi-v4/fooapp.png'

Thanks,

Matt