### PR TITLE
Revert "Clamping min_sdk version to 26 ..."

### DIFF
--- a/externally-hosted-apks/externallyhosted.py
+++ b/externally-hosted-apks/externallyhosted.py
@@ -17,9 +17,6 @@ import sys
 import tempfile
 import zipfile
 
-# Google Play Console now has a minimum version of 26.
-MIN_ALLOWED_SDK_VERSION = 26
-
 # Enable basic logging to stderr
 # logging.basicConfig(level=logging.DEBUG)
 logging.basicConfig(level=logging.WARNING)
@@ -138,12 +135,7 @@ class AaptParser(AbstractApkParser):
         output["version_name"] = matches.group(3)
       matches = self.SDK_VERSION_REGEX.match(line)
       if matches:
-        min_sdk = int(matches.group(1), 10)
-        if min_sdk < MIN_ALLOWED_SDK_VERSION:
-          _log.warn("Bumping min sdk from %s to %s",
-                    min_sdk, MIN_ALLOWED_SDK_VERSION)
-          min_sdk = MIN_ALLOWED_SDK_VERSION
-        output["minimum_sdk"] = str(min_sdk)
+        output["minimum_sdk"] = matches.group(1)
       matches = self.MAX_SDK_VERSION_REGEX.match(line)
       if matches:
         output["maximum_sdk"] = matches.group(1)


### PR DESCRIPTION
This reverts commit 75522d14cce1b9eefef99915d92e12b0bce7f4c1.

That was the wrong solution to the problem.  Upping the min_sdk version means the app can be published but it won't be available for older devices.