### PR TITLE
Fix version name regex wich include other information

### DIFF
--- a/externally-hosted-apks/externallyhosted.py
+++ b/externally-hosted-apks/externallyhosted.py
@@ -86,7 +86,7 @@ class AaptParser(AbstractApkParser):
   """
   PACKAGE_MATCH_REGEX = re.compile(
       r"\s*package:\s*name='(.*)'\s*"
-      r"versionCode='(\d+)'\s*versionName='(.+)'\s*")
+      r"versionCode='(\d+)'\s*versionName='([^']+)'\s*")
   APPLICATION_REGEX = re.compile(
       r"\s*application:\s*label='(.*)'\s*icon='(.*)'\s*")
   APPLICATION_LABEL = re.compile(r"\s*application-label:\s*'(.*)'\s*")


### PR DESCRIPTION
Fix version name regex wich include other information

Actual: 

 "version_name": "1.0.1.9' platformBuildVersionName='13' platformBuildVersionCode='33' compileSdkVersion='33' compileSdkVersionCodename='13", 

Fixed:

 "version_name": "1.0.1.9", 

Use [^']+ to exlude single quotes in version name
